### PR TITLE
Added ansible_managed header to template file

### DIFF
--- a/templates/zshrc.j2
+++ b/templates/zshrc.j2
@@ -1,3 +1,4 @@
+# {{ ansible_managed }}
 {% set oh_my_zsh = item.oh_my_zsh|default({}) %}
 
 # Path to your oh-my-zsh installation.


### PR DESCRIPTION
This is useful to tell users that a file has been placed by Ansible and manual changes are likely to be overwritten.