### PR TITLE
Fixed corrupted boot console prompt

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,3 +48,34 @@
     backup: yes
     mode: 'u=rw,go=r'
   with_items: "{{ users }}"
+
+# This is for the boot console only (i.e. not xterm, ssh or docker).
+# The oh-my-zsh prompt appears corrupted unless the console is in UTF-8.
+# If the console-setup file is missing don't create it... assume we're
+# running in an environment without a boot console (e.g. docker).
+- name: check if console-setup exists
+  stat:
+    path: /etc/default/console-setup
+  register: console_setup_file
+
+- name: install console-setup
+  become: yes
+  apt:
+    name: console-setup
+    state: present
+  when: console_setup_file.stat.exists
+
+- name: edit console-setup to utf-8
+  become: yes
+  lineinfile:
+    dest: /etc/default/console-setup
+    regexp: ^CHARMAP=
+    line: CHARMAP="UTF-8"
+    state: present
+  when: console_setup_file.stat.exists
+  register: console_setup
+
+- name: apply console configration
+  become: yes
+  command: /usr/sbin/dpkg-reconfigure -f noninteractive console-setup
+  when: console_setup.changed

--- a/tests/console-setup.sh
+++ b/tests/console-setup.sh
@@ -1,0 +1,16 @@
+# CONFIGURATION FILE FOR SETUPCON
+
+# Consult the console-setup(5) manual page.
+
+ACTIVE_CONSOLES="/dev/tty[1-6]"
+
+CHARMAP="ISO-8859-1"
+
+CODESET="Lat15"
+FONTFACE="VGA"
+FONTSIZE="8x16"
+
+VIDEOMODE=
+
+# The following is an example how to use a braille font
+# FONT='lat9w-08.psf.gz brl-8x8.psf'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -15,6 +15,15 @@
         name: test_usr2
         home: /home/test_usr2
         createhome: yes
+    - name: install console-setup file
+      become: yes
+      copy:
+        src: console-setup.sh
+        dest: /etc/default/console-setup
+        force: no
+        owner: root
+        group: root
+        mode: 'u=rwx,go=r'
 
   roles:
     - role: ansible-role-oh-my-zsh

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -23,3 +23,11 @@ def test_oh_my_zsh_config(File, username, theme, plugins):
     assert zshrc.group == username
     assert zshrc.contains(theme)
     assert zshrc.contains(plugins)
+
+def test_console_setup(File):
+    setup = File('/etc/default/console-setup')
+    assert setup.exists
+    assert setup.is_file
+    assert setup.user == 'root'
+    assert setup.group == 'root'
+    assert setup.contains('CHARMAP="UTF-8"')


### PR DESCRIPTION
Boot console needs to be in UTF-8.

Fix: resolves #15