### PR TITLE
Switched to single quotes for YAML strings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,40 +18,40 @@
     - skip_ansible_lint
   become: yes
   # core.autocrlf=input prevents https://github.com/robbyrussell/oh-my-zsh/issues/4402
-  command: "git clone -c core.autocrlf=input --depth=1 https://github.com/robbyrussell/oh-my-zsh.git ~{{ item.username }}/.oh-my-zsh"
+  command: 'git clone -c core.autocrlf=input --depth=1 https://github.com/robbyrussell/oh-my-zsh.git ~{{ item.username }}/.oh-my-zsh'
   args:
-    creates: "~{{ item.username }}/.oh-my-zsh"
-  with_items: "{{ users }}"
+    creates: '~{{ item.username }}/.oh-my-zsh'
+  with_items: '{{ users }}'
 
 - name: set ownership and permissions of oh-my-zsh for users
   become: yes
   file:
-    path: "~{{ item.username }}/.oh-my-zsh"
-    owner: "{{ item.username }}"
-    group: "{{ item.username }}"
+    path: '~{{ item.username }}/.oh-my-zsh'
+    owner: '{{ item.username }}'
+    group: '{{ item.username }}'
     # Prevent the cloned repository from having insecure permissions. Failing to do
     # so causes compinit() calls to fail with "command not found: compdef" errors
     # for users with insecure umasks (e.g., "002", allowing group writability).
     mode: 'go-w'
     recurse: yes
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'
 
 - name: set default shell for users
   become: yes
   user:
-    name: "{{ item.username }}"
+    name: '{{ item.username }}'
     shell: /bin/zsh
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'
 
 - name: write .zshrc for users
   become: yes
-  become_user: "{{ item.username }}"
+  become_user: '{{ item.username }}'
   template:
     src: zshrc.j2
     dest: '~{{ item.username }}/.zshrc'
     backup: yes
     mode: 'u=rw,go=r'
-  with_items: "{{ users }}"
+  with_items: '{{ users }}'
 
 # This is for the boot console only (i.e. not xterm, ssh or docker).
 # The oh-my-zsh prompt appears corrupted unless the console is in UTF-8.


### PR DESCRIPTION
Switched to single quotes (rather than double quotes) for YAML strings where escaping isn't required.