### PR TITLE
Renamed handler to be more specific

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
-- name: apply console configration
+- name: dpkg-reconfigure console-setup
   become: yes
   command: /usr/sbin/dpkg-reconfigure -f noninteractive console-setup

--- a/tasks/debian-console-setup.yml
+++ b/tasks/debian-console-setup.yml
@@ -24,4 +24,4 @@
     state: present
   when: console_setup_file.stat.exists
   notify:
-    - apply console configration
+    - dpkg-reconfigure console-setup


### PR DESCRIPTION
Since the handler is global it should be more specific as to its purpose.