### PR TITLE
Resolved deprecation warning for include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-- include: install.yml
+- import_tasks: install.yml
 
-- include: debian-console-setup.yml
+- name: console setup for Debian family distributions
+  include_tasks: debian-console-setup.yml
   when: ansible_os_family == 'Debian'


### PR DESCRIPTION
Since Ansible 2.4 `include` has been deprecated.

```
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use
'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions.
```