### PR TITLE
Dropped support for Debian Wheezy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Requirements
 
         * Debian
 
-            * Wheezy (7)
             * Jessie (8)
             * Stretch (9)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,7 +24,6 @@ galaxy_info:
     - name: Debian
       versions:
         - jessie
-        - wheezy
         - stretch
   galaxy_tags:
     - ohmyzsh

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ lint:
 
 platforms:
   - name: ansible-role-oh-my-zsh-debian-min
-    image: debian:7
+    image: debian:8
   - name: ansible-role-oh-my-zsh-debian-max
     image: debian:9
   - name: ansible-role-oh-my-zsh-ubuntu-min


### PR DESCRIPTION
Debian ended support in May 2018.