### PR TITLE
Updated install.yml

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,24 +14,27 @@
     # Git module doesn't allow us to set `core.autocrlf=input`.
     - skip_ansible_lint
   become: yes
-  become_user: '{{ item.username }}'
+  become_user: root
   # core.autocrlf=input prevents https://github.com/robbyrussell/oh-my-zsh/issues/4402
   command: 'git clone -c core.autocrlf=input --depth=1 https://github.com/robbyrussell/oh-my-zsh.git .oh-my-zsh'
   args:
     chdir: '~{{ item.username }}'
     creates: '~{{ item.username }}/.oh-my-zsh'
   with_items: '{{ users }}'
+  when: item.oh_my_zsh is defined
 
 - name: set permissions of oh-my-zsh for users
   become: yes
   file:
     path: '~{{ item.username }}/.oh-my-zsh'
+    owner: '{{ item.username }}'
     # Prevent the cloned repository from having insecure permissions. Failing to do
     # so causes compinit() calls to fail with "command not found: compdef" errors
     # for users with insecure umasks (e.g., "002", allowing group writability).
     mode: 'go-w'
     recurse: yes
   with_items: '{{ users }}'
+  when: item.oh_my_zsh is defined
 
 - name: set default shell for users
   become: yes
@@ -39,13 +42,16 @@
     name: '{{ item.username }}'
     shell: /bin/zsh
   with_items: '{{ users }}'
+  when: item.oh_my_zsh is defined
 
 - name: write .zshrc for users
   become: yes
-  become_user: '{{ item.username }}'
+  become_user: root
   template:
     src: zshrc.j2
     dest: '~{{ item.username }}/.zshrc'
     backup: yes
+    owner: '{{ item.username }}'
     mode: 'u=rw,go=r'
   with_items: '{{ users }}'
+  when: item.oh_my_zsh is defined

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,11 +2,8 @@
 - name: install dependencies
   become: yes
   package:
-    name: '{{ item }}'
+    name: ['git', 'zsh']
     state: present
-  with_items:
-    - git
-    - zsh
 
 - name: clone oh-my-zsh for users
   tags:
@@ -18,40 +15,52 @@
   # core.autocrlf=input prevents https://github.com/robbyrussell/oh-my-zsh/issues/4402
   command: 'git clone -c core.autocrlf=input --depth=1 https://github.com/robbyrussell/oh-my-zsh.git .oh-my-zsh'
   args:
-    chdir: '~{{ item.username }}'
-    creates: '~{{ item.username }}/.oh-my-zsh'
-  with_items: '{{ users }}'
-  when: item.oh_my_zsh is defined
+    chdir: '~{{ user.username }}'
+    creates: '~{{ user.username }}/.oh-my-zsh'
+  loop: "{{ users }}"
+  loop_control:
+    loop_var: user
+    label: [ "{{ user.username }}" ]
+  when: "user.oh_my_zsh is defined"
 
 - name: set permissions of oh-my-zsh for users
   become: yes
   file:
-    path: '~{{ item.username }}/.oh-my-zsh'
-    owner: '{{ item.username }}'
+    path: '~{{ user.username }}/.oh-my-zsh'
+    owner: '{{ user.username }}'
     # Prevent the cloned repository from having insecure permissions. Failing to do
     # so causes compinit() calls to fail with "command not found: compdef" errors
     # for users with insecure umasks (e.g., "002", allowing group writability).
     mode: 'go-w'
     recurse: yes
-  with_items: '{{ users }}'
-  when: item.oh_my_zsh is defined
+  loop: "{{ users }}"
+  loop_control:
+    loop_var: user
+    label: [ "{{ user.username }}" ]
+  when: "user.oh_my_zsh is defined"
 
 - name: set default shell for users
   become: yes
   user:
-    name: '{{ item.username }}'
+    name: '{{ user.username }}'
     shell: /bin/zsh
-  with_items: '{{ users }}'
-  when: item.oh_my_zsh is defined
+  loop: "{{ users }}"
+  loop_control:
+    loop_var: user
+    label: [ "{{ user.username }}" ]
+  when: "user.oh_my_zsh is defined"
 
 - name: write .zshrc for users
   become: yes
   become_user: root
   template:
     src: zshrc.j2
-    dest: '~{{ item.username }}/.zshrc'
+    dest: '~{{ user.username }}/.zshrc'
     backup: yes
-    owner: '{{ item.username }}'
+    owner: '{{ user.username }}'
     mode: 'u=rw,go=r'
-  with_items: '{{ users }}'
-  when: item.oh_my_zsh is defined
+  loop: "{{ users }}"
+  loop_control:
+    loop_var: user
+    label: [ "{{ user.username }}" ]
+  when: "user.oh_my_zsh is defined"


### PR DESCRIPTION
- Replaced end-user with root in become_user parameter. OpenBSD has no
  setacl command, therefore that role won't work on that OS (see
https://github.com/ansible/ansible/issues/16758). For that reason I set
become_user to root on tasks which require elevated access rights. Also,
I explicitly set the file owner for the set permissions task and
.zshrc.j2 template.
- Added the ability to skip users who do not have oh_my_zsh parameter in
  vars.