### PR TITLE
Dropped support for Ubuntu Trusty

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Requirements
 
         * Ubuntu
 
-            * Trusty (14.04)
             * Xenial (16.04)
             * Bionic (18.04)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,7 +17,6 @@ galaxy_info:
         - 15.1
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
         - bionic
     - name: Debian

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,7 +14,7 @@ platforms:
   - name: ansible-role-oh-my-zsh-debian-max
     image: debian:9
   - name: ansible-role-oh-my-zsh-ubuntu-min
-    image: ubuntu:14.04
+    image: ubuntu:16.04
   - name: ansible-role-oh-my-zsh-ubuntu-max
     image: ubuntu:18.04
   - name: ansible-role-oh-my-zsh-centos


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Trusty (14.04).