### PR TITLE
Updated to not use `become` when run under OSX.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,6 +6,17 @@
       - git
       - zsh
     state: present
+  when:
+    - ansible_distribution != 'MacOSX'
+
+- name: install dependencies (OSX only)
+  package:
+    name:
+      - git
+      - zsh
+    state: present
+  when:
+    - ansible_distribution == 'MacOSX'
 
 - name: clone oh-my-zsh for users
   tags:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,22 +1,11 @@
 ---
 - name: install dependencies
-  become: yes
+  become: "{{ ansible_distribution != 'MacOSX' }}"
   package:
     name:
       - git
       - zsh
     state: present
-  when:
-    - ansible_distribution != 'MacOSX'
-
-- name: install dependencies (OSX only)
-  package:
-    name:
-      - git
-      - zsh
-    state: present
-  when:
-    - ansible_distribution == 'MacOSX'
 
 - name: clone oh-my-zsh for users
   tags:


### PR DESCRIPTION
This corrects the issue reported in #106 by using a different task to install required packages when the role is installed in OSX, which removes the `become` attribute.