### PR TITLE
Allow conditional install per user

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ users:
         - git
         - mvn
 ```
+Sometimes you would like to use list of users to create them in another role but with another shell. In this case you should disable installing oh_my_zsh for excluded user by specifying `install_oh_my_zsh: false` on single user dict.
+
+```yaml
+users:
+  - username: bashuser
+    install_oh_my_zsh: false
+```
 
 Example Playbook
 ----------------

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -12,6 +12,7 @@
       with_items:
         - test_usr1
         - test_usr2
+        - test_usr3
 
     - name: install console-setup file
       become: yes
@@ -37,3 +38,5 @@
             plugins:
               - test_plugin3
               - test_plugin4
+        - username: test_usr3
+          install_oh_my_zsh: no

--- a/molecule/default/tests/test_role.py
+++ b/molecule/default/tests/test_role.py
@@ -20,6 +20,16 @@ def test_oh_my_zsh_install(host, username):
     assert oh_my_zsh.group in [username, 'users']
 
 
+@pytest.mark.parametrize('username', [
+    'test_usr3',
+])
+def test_oh_my_zsh_is_not_installed_for_excluded_users(host, username):
+    oh_my_zsh = host.file('/home/' + username + '/.oh-my-zsh')
+    zshrc = host.file('/home/' + username + '/.zshrc')
+    assert not oh_my_zsh.exists
+    assert not zshrc.exists
+
+
 @pytest.mark.parametrize('username,theme,plugins', [
     ('test_usr1', 'test_theme1', 'test_plugin1 test_plugin2'),
     ('test_usr2', 'test_theme2', 'test_plugin3 test_plugin4'),

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,37 +13,40 @@
     # Git module doesn't allow us to set `core.autocrlf=input`.
     - skip_ansible_lint
   become: yes
-  become_user: '{{ username }}'
+  become_user: '{{ user.username }}'
   # core.autocrlf=input prevents https://github.com/robbyrussell/oh-my-zsh/issues/4402
   command: 'git clone -c core.autocrlf=input --depth=1 https://github.com/robbyrussell/oh-my-zsh.git .oh-my-zsh'
   args:
-    chdir: '~{{ username }}'
-    creates: '~{{ username }}/.oh-my-zsh'
-  with_items: "{{ users | map(attribute='username') | list }}"
+    chdir: '~{{ user.username }}'
+    creates: '~{{ user.username }}/.oh-my-zsh'
+  with_items: "{{ users }}"
+  when: user.install_oh_my_zsh | default('true')
   loop_control:
-    loop_var: username
+    loop_var: user
 
 - name: set permissions of oh-my-zsh for users
   become: yes
   file:
-    path: '~{{ username }}/.oh-my-zsh'
+    path: '~{{ user.username }}/.oh-my-zsh'
     # Prevent the cloned repository from having insecure permissions. Failing to do
     # so causes compinit() calls to fail with "command not found: compdef" errors
     # for users with insecure umasks (e.g., "002", allowing group writability).
     mode: 'go-w'
     recurse: yes
-  with_items: "{{ users | map(attribute='username') | list }}"
+  with_items: "{{ users }}"
+  when: user.install_oh_my_zsh | default('yes')
   loop_control:
-    loop_var: username
+    loop_var: user
 
 - name: set default shell for users
   become: yes
   user:
-    name: '{{ username }}'
+    name: '{{ user.username }}'
     shell: /bin/zsh
-  with_items: "{{ users | map(attribute='username') | list }}"
+  with_items: "{{ users }}"
+  when: user.install_oh_my_zsh | default('yes')
   loop_control:
-    loop_var: username
+    loop_var: user
 
 - name: write .zshrc for users
   become: yes
@@ -54,6 +57,7 @@
     backup: yes
     mode: 'u=rw,go=r'
   with_items: '{{ users }}'
+  when: user.install_oh_my_zsh | default('yes')
   loop_control:
     loop_var: user
     label: '{{ user.username }}'


### PR DESCRIPTION
Variable `users` is often used in other roles, mainly for creating users. Such roles allow specifying a default shell for a user. However, this role forces having zsh for each user specified in `users` list. 
My PR allows setting `install_oh_my_zsh` to `false` to omit particular users when installing oh-my-zsh. 