### PR TITLE
Made the package names of the git and zsh package variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ oh_my_zsh_plugins:
 # May be overridden by `oh_my_zsh: install:` under each user.
 oh_my_zsh_install: yes
 
+# Name of the git package of your Linux distribution
+git_pkg: git
+
+# Name of the zsh package of your Linux distribution
+zsh_pkg: zsh
+
 # User configuration
 # Important: oh-my-zsh is installed per user so you need to specify the users to install it for.
 users:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,8 +3,8 @@
   become: "{{ ansible_distribution != 'MacOSX' }}"
   package:
     name:
-      - git
-      - zsh
+      - "{{ git_pkg | default('git') }}"
+      - "{{ zsh_pkg | default('zsh') }}"
     state: present
 
 - name: clone oh-my-zsh for users


### PR DESCRIPTION
Since pkg names can differ on some systems ( e.g. between OpenSUSE and SLES) it would be benefitial to have the package names as a variable and allow the user to change theses names if needed. 
With the changes in this pull request the provided package names are used as a default value for the newly introduced variables `git_pkg` and `zsh_pkg`. THey don't interfere with the current behaviour of the role and are only needed when the user has a target system with different package names for these two packages. 