### PR TITLE
Dropped support for Debian Jessie

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Requirements
 
         * Debian
 
-            * Jessie (8)
             * Stretch (9)
             * Buster (10)
             * Bullseye (11)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,7 +21,6 @@ galaxy_info:
         - bionic
     - name: Debian
       versions:
-        - jessie
         - stretch
         - buster
         - bullseye

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible-role-oh-my-zsh-debian-min
-    image: debian:8
+    image: debian:9
   - name: ansible-role-oh-my-zsh-debian-max
     image: debian:11
   - name: ansible-role-oh-my-zsh-ubuntu-min


### PR DESCRIPTION
Debian ended LTS support in June 2020.