### PR TITLE
Dropped support for Ubuntu Xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Requirements
 
         * Ubuntu
 
-            * Xenial (16.04)
             * Bionic (18.04)
             * Focal (20.04)
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,7 +17,6 @@ galaxy_info:
         - 15.1
     - name: Ubuntu
       versions:
-        - xenial
         - bionic
         - focal
     - name: Debian

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -17,7 +17,7 @@ platforms:
   - name: ansible-role-oh-my-zsh-debian-max
     image: debian:11
   - name: ansible-role-oh-my-zsh-ubuntu-min
-    image: ubuntu:16.04
+    image: ubuntu:18.04
   - name: ansible-role-oh-my-zsh-ubuntu-max
     image: ubuntu:20.04
   - name: ansible-role-oh-my-zsh-centos


### PR DESCRIPTION
Canonical have ended standard support for Ubuntu Xenial.