### PR TITLE
Replaced CentOS 7 tests with Rocky Linux 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Requirements
 
     * RedHat Family
 
-        * CentOS
+        * Rocky Linux
 
-            * 7
+            * 8
 
         * Fedora
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 7
+        - 8
     - name: Fedora
       versions:
         - 31

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,8 +20,8 @@ platforms:
     image: ubuntu:18.04
   - name: ansible-role-oh-my-zsh-ubuntu-max
     image: ubuntu:20.04
-  - name: ansible-role-oh-my-zsh-centos
-    image: centos:7
+  - name: ansible-role-oh-my-zsh-rocky
+    image: rockylinux/rockylinux:8
   - name: ansible-role-oh-my-zsh-fedora
     image: fedora:31
   - name: ansible-role-oh-my-zsh-opensuse


### PR DESCRIPTION
RedHat have discontinued the downstream version of CentOS.